### PR TITLE
Add basic Chrome extension skeleton

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,16 @@
+# Survivor AI Extension
+
+This repository contains a minimal Chrome extension scaffold using Manifest V3. It sets up a service worker, content script, popup, and a context menu entry.
+
+## Setup
+
+1. Clone the repository.
+2. Open Chrome and navigate to `chrome://extensions`.
+3. Enable **Developer mode**.
+4. Click **Load unpacked** and select this directory.
+
+## Usage
+
+After loading, right-click on any page to see a "Survivor AI Action" entry in the context menu. The popup can be opened by clicking the extension icon.
+
+This skeleton does not include any actual functionality yet; use it as a starting point for development.

--- a/background.js
+++ b/background.js
@@ -1,0 +1,12 @@
+// Placeholder background script
+chrome.runtime.onInstalled.addListener(() => {
+  chrome.contextMenus.create({
+    id: 'survivor-ai',
+    title: 'Survivor AI Action',
+    contexts: ['all']
+  });
+});
+
+chrome.contextMenus.onClicked.addListener((info, tab) => {
+  // TODO: implement functionality
+});

--- a/content.js
+++ b/content.js
@@ -1,0 +1,2 @@
+// Placeholder content script
+// TODO: interact with page content

--- a/manifest.json
+++ b/manifest.json
@@ -1,0 +1,14 @@
+{
+  "manifest_version": 3,
+  "name": "Survivor AI Extension",
+  "version": "0.1",
+  "description": "Skeleton for Survivor AI Chrome extension",
+  "permissions": ["contextMenus", "activeTab", "storage"],
+  "host_permissions": ["<all_urls>"],
+  "background": {
+    "service_worker": "background.js"
+  },
+  "action": {
+    "default_popup": "popup.html"
+  }
+}

--- a/popup.html
+++ b/popup.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <meta charset="UTF-8">
+  <title>Survivor AI</title>
+  <script src="popup.js" defer></script>
+</head>
+<body>
+  <h1>Survivor AI</h1>
+  <p>Extension initialized.</p>
+</body>
+</html>

--- a/popup.js
+++ b/popup.js
@@ -1,0 +1,2 @@
+// Placeholder popup script
+console.log('Survivor AI popup loaded');


### PR DESCRIPTION
## Summary
- add minimal Manifest V3 configuration
- create background, content and popup scripts
- show placeholder popup and context menu
- document installation and usage in README

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_686b8a012e74832da3d2f13a7a4dd24a